### PR TITLE
fix: update headers path during nix build

### DIFF
--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -76,9 +76,9 @@ pkgs.stdenv.mkDerivation {
     fi
     
     # Also install the generated include files
-    if [ -d "./generated_code/include" ]; then
+    if [ -d "../generated_code/include" ]; then
       mkdir -p $out/include
-      cp -r ./generated_code/include/* $out/include/
+      cp -r ../generated_code/include/* $out/include/
       echo "Installed generated include files:"
       ls -la $out/include/
     fi


### PR DESCRIPTION
While working on setting up my environment with Qt Creator, I noticed that the file `logos_sdk.h` was not included in the result folder.  Looking into the logs of the Nix build for library I found: 

```
logos-chat-ui-lib> Running phase: glibPreInstallPhase
logos-chat-ui-lib> Running phase: installPhase
logos-chat-ui-lib> Running phase: qtOwnPathsHook
logos-chat-ui-lib> Running phase: fixupPhase
```

If we look at `lib.nix`, the following section does not seem to be triggered : 

```
  # Also install the generated include files
  if [ -d "./generated_code/include" ]; then
    mkdir -p $out/include
    cp -r ./generated_code/include/* $out/include/
    echo "Installed generated include files:"
    ls -la $out/include/
  fi
```

If we replace the `./generated_code/` to `../generated_code/` (notice the double dot), the execution behaves as expected: 

```
logos-chat-ui-lib> Running phase: glibPreInstallPhase
logos-chat-ui-lib> Running phase: installPhase
logos-chat-ui-lib> Installed generated include files:
logos-chat-ui-lib> total 24
logos-chat-ui-lib> drwxr-xr-x 1 nixbld nixbld  168 Jan 21 13:24 .
logos-chat-ui-lib> drwxr-xr-x 1 nixbld nixbld   20 Jan 21 13:24 ..
logos-chat-ui-lib> -r--r--r-- 1 nixbld nixbld 2955 Jan 21 13:24 chat_api.cpp
logos-chat-ui-lib> lrwxrwxrwx 1 nixbld nixbld   94 Jan 21 13:24 chat_api.h -> /nix/store/ym9y94wq6b2mymhwp39fsrbcjzp01xsz-logos-chat-module-headers-1.0.0/include/chat_api.h
logos-chat-ui-lib> -rw-r--r-- 1 nixbld nixbld 3993 Jan 21 13:24 core_manager_api.cpp
logos-chat-ui-lib> -rw-r--r-- 1 nixbld nixbld 2179 Jan 21 13:24 core_manager_api.h
logos-chat-ui-lib> -rw-r--r-- 1 nixbld nixbld   81 Jan 21 13:24 logos_sdk.cpp
logos-chat-ui-lib> -rw-r--r-- 1 nixbld nixbld  312 Jan 21 13:24 logos_sdk.h
logos-chat-ui-lib> Running phase: qtOwnPathsHook
logos-chat-ui-lib> Running phase: fixupPhase
```

This PR changes the path  `./generated_code/` to `"../generated_code/`, in order to include those missing headers and files.